### PR TITLE
AG-40 - Add MQTT asyncapi definition for Agent Service

### DIFF
--- a/api/asynapi/mqtt.yaml
+++ b/api/asynapi/mqtt.yaml
@@ -1,0 +1,21 @@
+asyncapi: 2.6.0
+info:
+  title: Agent Service
+  version: 0.13
+  description: Agent service provides remote command execution, remote terminal, heartbeat service for services on edge and edgex SMA.
+channels:
+  channels/{channel_id}/messages/req:
+    publish:
+      message:
+        $ref: '#/componenets/messages/agentMessage'
+components:
+  messages:
+    agentMessage:
+      payload:
+        type: object
+        example: |
+        ### SenML
+        ```json
+        [{"bn":"1:", "n":"<command>", "vs":"<content>"}]
+        ```
+        #### Commands: exec, control, config, service, term


### PR DESCRIPTION
This commit adds the MQTT asyncapi definition for the Agent Service. It includes the necessary channels and messages for remote command execution, remote terminal, heartbeat service, and other functionalities. The asyncapi version is set to 2.6.0, and the Agent Service version is 0.13. The description provides an overview of the Agent Service's capabilities. The example payload is included, demonstrating the usage of SenML for different commands.

Signed-off-by: SammyOina <sammyoina@gmail.com>

Pull request title should be `MF-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/mainflux/mainflux/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### What does this do?

### Which issue(s) does this PR fix/relate to?
Resolves #40 

### List any changes that modify/break current functionality

### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes